### PR TITLE
Refactored Launch and NodeExecutor

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -144,7 +144,11 @@ if __name__ == "__main__":
 
     ignition()
 
+    conn.space_center.physics_war_factor = 2
+
     ascent()
+
+    conn.space_center.physics_war_factor = 0
 
     execute_node(circularization())
 

--- a/Launcher.py
+++ b/Launcher.py
@@ -52,7 +52,7 @@ burn_time_to_circularize = 90 # hardcoded for now, calculate eventually
 # setting up streams
 ut = conn.add_stream(getattr, conn.space_center, 'ut')
 
-def countdown(require_click=True):
+def hold_for_click(require_click=True):
     # wait button click to launch
     if require_click:
         update_UI('Click to launch')
@@ -170,7 +170,7 @@ def goodbye():
 
 # main loop
 if __name__ == "__main__":
-    countdown()
+    hold_for_click()
 
     ignition()
 

--- a/Launcher.py
+++ b/Launcher.py
@@ -27,19 +27,15 @@ Padding_h = 65
 rect.size = (width, height)
 rect.position = (width/2+padding_w-screen_size[0]/2, screen_size[1]/2-(height/2+Padding_h))
 
-button = panel.add_button("Launch")
-button.rect_transform.size=(100,30)
-button.rect_transform.position = (135, -20)
-
 # Add some text displaying messages to user
-text = panel.add_text("Autopilot ready")
+text = panel.add_text("...")
 text.rect_transform.size = (380, 30)
 text.rect_transform.position = (0, +20)
 text.color = (1, 1, 1)
 text.size = 18
 
 # defining a display function to update terminal & UI at the same time
-def update_UI(message='Testing UI'):
+def update_UI(message='...'):
     print(message)
     text.content = message
     return
@@ -54,106 +50,132 @@ target_apoapsis = 100*1000
 burn_time_to_circularize = 90 # hardcoded for now, calculate eventually
 
 # setting up streams
-button_clicked = conn.add_stream(getattr, button, 'clicked')
 ut = conn.add_stream(getattr, conn.space_center, 'ut')
 
-# wait for button click
-while True:
-    if button_clicked():
-        break
-    time.sleep(0.1)
+def countdown(require_click=True):
+    # wait button click to launch
+    if require_click:
+        update_UI('Click to launch')
+        button = panel.add_button("Launch")
+        button.rect_transform.size=(100,30)
+        button.rect_transform.position = (135, -20)
+        button_clicked = conn.add_stream(getattr, button, 'clicked')
+        while True:
+            if button_clicked():
+                button.clicked = False
+                break
+            time.sleep(0.1)
+        button.remove()
+    return
 
-# roll is less critical, and tends to oscillate
-vessel.auto_pilot.time_to_peak=(5,10,5)
-vessel.auto_pilot.overshoot=(0.005,0.010,0.005)
+def ignition():
+    # roll is less critical, and tends to oscillate
+    vessel.auto_pilot.time_to_peak=(5,10,5)
+    vessel.auto_pilot.overshoot=(0.005,0.010,0.005)
 
-# setting up autopilot
-vessel.auto_pilot.reference_frame = vessel.surface_reference_frame
-vessel.auto_pilot.target_pitch=90
-vessel.auto_pilot.target_heading=90-target_inclination
-vessel.auto_pilot.target_roll=0
-vessel.auto_pilot.engage()
-update_UI('Autopilot taking control')
+    # setting up autopilot
+    vessel.auto_pilot.reference_frame = vessel.surface_reference_frame
+    vessel.auto_pilot.target_pitch=90
+    vessel.auto_pilot.target_heading=90-target_inclination
+    vessel.auto_pilot.target_roll=0
+    vessel.auto_pilot.engage()
+    update_UI('Autopilot taking control')
 
-# setting throttle
-vessel.control.throttle = 1
-time.sleep(1)
+    # setting throttle
+    vessel.control.throttle = 1
+    time.sleep(1)
 
-# releasing clamps & igniting first stage
-vessel.control.activate_next_stage()
-update_UI('Ignition')
+    # releasing clamps & igniting first stage
+    vessel.control.activate_next_stage()
+    update_UI('Ignition')
+    return
 
-# waiting for altitude to exceed 200 meters before initial pitch over
-mean_altitude = conn.get_call(getattr, vessel.flight(), 'mean_altitude')
-expr = conn.krpc.Expression.greater_than(
-    conn.krpc.Expression.call(mean_altitude),
-    conn.krpc.Expression.constant_double(300))
-event = conn.krpc.add_event(expr)
-with event.condition:
-    event.wait()
-vessel.auto_pilot.target_pitch=90-initial_pitch_over
-update_UI('Initial pitch over')
+def ascent():
+    # waiting for altitude to exceed 200 meters before initial pitch over
+    mean_altitude = conn.get_call(getattr, vessel.flight(), 'mean_altitude')
+    expr = conn.krpc.Expression.greater_than(
+        conn.krpc.Expression.call(mean_altitude),
+        conn.krpc.Expression.constant_double(300))
+    event = conn.krpc.add_event(expr)
+    with event.condition:
+        event.wait()
+    vessel.auto_pilot.target_pitch=90-initial_pitch_over
+    update_UI('Initial pitch over')
 
-# poiting prograde relative to atmosphere at 5km altitude
-expr = conn.krpc.Expression.greater_than(
-    conn.krpc.Expression.call(mean_altitude),
-    conn.krpc.Expression.constant_double(5000))
-event = conn.krpc.add_event(expr)
-with event.condition:
-    event.wait()
-vessel.auto_pilot.disengage()
-vessel.auto_pilot.reference_frame = vessel.surface_velocity_reference_frame
-vessel.auto_pilot.target_pitch=0
-vessel.auto_pilot.target_heading=0
-vessel.auto_pilot.target_roll=0
-vessel.auto_pilot.engage()
-update_UI('Initiating gravity turn')
+    # poiting prograde relative to atmosphere at 5km altitude
+    expr = conn.krpc.Expression.greater_than(
+        conn.krpc.Expression.call(mean_altitude),
+        conn.krpc.Expression.constant_double(5000))
+    event = conn.krpc.add_event(expr)
+    with event.condition:
+        event.wait()
+    vessel.auto_pilot.disengage()
+    vessel.auto_pilot.reference_frame = vessel.surface_velocity_reference_frame
+    vessel.auto_pilot.target_pitch=0
+    vessel.auto_pilot.target_heading=0
+    vessel.auto_pilot.target_roll=0
+    vessel.auto_pilot.engage()
+    update_UI('Initiating gravity turn')
 
-# waiting for altitude to match target before switching reference_frame
-expr = conn.krpc.Expression.greater_than(
-    conn.krpc.Expression.call(mean_altitude),
-    conn.krpc.Expression.constant_double(transition_altitude))
-event = conn.krpc.add_event(expr)
-with event.condition:
-    event.wait()
-vessel.auto_pilot.disengage()
-vessel.auto_pilot.reference_frame = vessel.orbital_reference_frame
-vessel.auto_pilot.target_pitch=0
-vessel.auto_pilot.target_heading=0
-vessel.auto_pilot.target_roll=180 # Swaps around between frames!
-vessel.auto_pilot.engage()
-update_UI('Transitioning to orbital reference frame')
+    # waiting for altitude to match target before switching reference_frame
+    expr = conn.krpc.Expression.greater_than(
+        conn.krpc.Expression.call(mean_altitude),
+        conn.krpc.Expression.constant_double(transition_altitude))
+    event = conn.krpc.add_event(expr)
+    with event.condition:
+        event.wait()
+    vessel.auto_pilot.disengage()
+    vessel.auto_pilot.reference_frame = vessel.orbital_reference_frame
+    vessel.auto_pilot.target_pitch=0
+    vessel.auto_pilot.target_heading=0
+    vessel.auto_pilot.target_roll=180 # Swaps around between frames!
+    vessel.auto_pilot.engage()
+    update_UI('Transitioning to orbital reference frame')
 
-# waiting for apoapsis to match target before coasting
-apoapsis_altitude = conn.get_call(getattr, vessel.orbit, 'apoapsis_altitude')
-expr = conn.krpc.Expression.greater_than(
-    conn.krpc.Expression.call(apoapsis_altitude),
-    conn.krpc.Expression.constant_double(target_apoapsis))
-event = conn.krpc.add_event(expr)
-with event.condition:
-    event.wait()
-vessel.control.throttle = 0
-vessel.auto_pilot.disengage()
-vessel.auto_pilot.reference_frame = vessel.surface_reference_frame
-vessel.auto_pilot.target_pitch=0
-vessel.auto_pilot.target_heading=90-target_inclination
-vessel.auto_pilot.target_roll=0 # Swaps around between frames!
-vessel.auto_pilot.engage()
-update_UI('Coasting to apoapsis')
+    # waiting for apoapsis to match target before coasting
+    apoapsis_altitude = conn.get_call(getattr, vessel.orbit, 'apoapsis_altitude')
+    expr = conn.krpc.Expression.greater_than(
+        conn.krpc.Expression.call(apoapsis_altitude),
+        conn.krpc.Expression.constant_double(target_apoapsis))
+    event = conn.krpc.add_event(expr)
+    with event.condition:
+        event.wait()
+    vessel.control.throttle = 0
+    vessel.auto_pilot.disengage()
+    vessel.auto_pilot.reference_frame = vessel.surface_reference_frame
+    vessel.auto_pilot.target_pitch=0
+    vessel.auto_pilot.target_heading=90-target_inclination
+    vessel.auto_pilot.target_roll=0 # Swaps around between frames!
+    vessel.auto_pilot.engage()
+    update_UI('Coasting to apoapsis')
+    return
 
-# setting up circulization maneuver
-mu = vessel.orbit.body.gravitational_parameter
-r = vessel.orbit.apoapsis
-a1 = vessel.orbit.semi_major_axis
-a2 = r
-v1 = sqrt(mu*((2./r)-(1./a1)))
-v2 = sqrt(mu*((2./r)-(1./a2)))
-delta_v = v2 - v1
-node = vessel.control.add_node(
-    ut() + vessel.orbit.time_to_apoapsis, prograde=delta_v)
+def circularization():
+    # setting up circulization maneuver
+    mu = vessel.orbit.body.gravitational_parameter
+    r = vessel.orbit.apoapsis
+    a1 = vessel.orbit.semi_major_axis
+    a2 = r
+    v1 = sqrt(mu*((2./r)-(1./a1)))
+    v2 = sqrt(mu*((2./r)-(1./a2)))
+    delta_v = v2 - v1
+    node = vessel.control.add_node(
+        ut() + vessel.orbit.time_to_apoapsis, prograde=delta_v)
+    return node
 
-# execute node
-execute_node(node)
+def goodbye():
+    update_UI('Enjoy your orbit!')
+    time.sleep(3)
+    return
 
-# handing control back
-update_UI('Autopilot releasing control')
+# main loop
+if __name__ == "__main__":
+    countdown()
+
+    ignition()
+
+    ascent()
+
+    execute_node(circularization())
+
+    goodbye()

--- a/NodeExecutor.py
+++ b/NodeExecutor.py
@@ -83,10 +83,11 @@ def execute_node(node):
 
     # point to maneuver
     update_UI('Aligning to burn')
-    conn.space_center.physics_war_factor = 0
     ap.reference_frame = node.reference_frame
     ap.target_direction = (0, 1, 0)
+    ap.target_roll = float('nan')
     ap.engage()
+    time.sleep(0.1)
     ap.wait()
 
     # warp to burn

--- a/NodeExecutor.py
+++ b/NodeExecutor.py
@@ -3,6 +3,7 @@
 from math import exp
 import time
 import krpc
+
 conn = krpc.connect(name='Node Executor')
 
 # Set up the UI
@@ -20,7 +21,7 @@ rect.size = (400, 100)
 rect.position = (210-(screen_size[0]/2), 300)
 
 # Add some text displaying messages to user
-text = panel.add_text("Retrieving next maneuver node")
+text = panel.add_text("...")
 text.rect_transform.size = (380, 30)
 text.rect_transform.position = (0, +20)
 text.color = (1, 1, 1)

--- a/NodeExecutor.py
+++ b/NodeExecutor.py
@@ -83,6 +83,7 @@ def execute_node(node):
 
     # point to maneuver
     update_UI('Aligning to burn')
+    conn.space_center.physics_war_factor = 0
     ap.reference_frame = node.reference_frame
     ap.target_direction = (0, 1, 0)
     ap.engage()

--- a/NodeExecutor.py
+++ b/NodeExecutor.py
@@ -4,7 +4,7 @@ from math import exp
 import time
 import krpc
 
-conn = krpc.connect(name='Node Executor')
+conn = krpc.connect(name='NodeExecutor')
 
 # Set up the UI
 canvas = conn.ui.stock_canvas
@@ -17,8 +17,12 @@ panel = canvas.add_panel()
 
 # Position the panel relative to the center of the screen
 rect = panel.rect_transform
-rect.size = (400, 100)
-rect.position = (210-(screen_size[0]/2), 300)
+width = 400
+height = 80
+padding_w = 0
+Padding_h = 65 + height
+rect.size = (width, height)
+rect.position = (width/2+padding_w-screen_size[0]/2, screen_size[1]/2-(height/2+Padding_h))
 
 # Add some text displaying messages to user
 text = panel.add_text("...")
@@ -137,5 +141,6 @@ def execute_node(node):
     return
 
 # main loop
-while True:
-    execute_node(get_node())
+if __name__ == "__main__":
+    while True:
+        execute_node(get_node())


### PR DESCRIPTION
NodeExecutor is now a module or a script, and Launcher calls it to execute the circularization burn.

Hardest bug to squash was figuring out that when you align with the burn, you should let the autopilot know that you don't care about roll. Also that you need to sleep(0.1) between enabling it and waiting for it to point where you want it, for some reason.